### PR TITLE
View Transitions API + CSS scroll-driven reveals

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,24 +35,6 @@
         });
     }
 
-    // Reveal-on-scroll
-    var revealEls = document.querySelectorAll('[data-reveal]');
-    if (revealEls.length) {
-        if ('IntersectionObserver' in window) {
-            var observer = new IntersectionObserver(function (entries) {
-                entries.forEach(function (entry) {
-                    if (entry.isIntersecting) {
-                        entry.target.classList.add('is-visible');
-                        observer.unobserve(entry.target);
-                    }
-                });
-            }, { threshold: 0.15, rootMargin: '0px 0px -40px 0px' });
-            revealEls.forEach(function (el) { observer.observe(el); });
-        } else {
-            revealEls.forEach(function (el) { el.classList.add('is-visible'); });
-        }
-    }
-
     // Kalender — fremhæv begivenheden midt i billedet, når man
     // scroller på en touch-enhed (samme effekt som hover på desktop)
     var eventList = document.querySelector('.event-list');
@@ -117,15 +99,6 @@
             var viaTop = Math.min(maxScroll, Math.max(0, lastRowBottom - window.innerHeight));
 
             if (viaTop > target + 1) {
-                // Kalenderens [data-reveal]-fade skal ikke nå at spille af midt
-                // i intro-rullet — den er ellers usynlig (opacity: 0), når
-                // siden starter nede ved viaTop, hvilket ses som om kalenderen
-                // "ankommer" for sig selv lige inden snappet i toppen
-                eventList.style.transition = 'none';
-                eventList.classList.add('is-visible');
-                void eventList.offsetHeight;
-                eventList.style.transition = '';
-
                 window.scrollTo({ top: viaTop, behavior: 'instant' });
 
                 // #main's "page-reveal"-transform kører i ca. 1100ms og

--- a/styles.css
+++ b/styles.css
@@ -897,11 +897,26 @@ p { margin: 0 0 var(--space-4); max-width: 56ch; text-wrap: pretty; }
 
 /* =====================================================
    Reveal-on-scroll — subtle
+   Pure CSS via scroll-driven animations: each [data-reveal]
+   element fades/slides in as it enters the viewport, scrubbed
+   by its own view-progress timeline (off the main thread, no
+   IntersectionObserver needed). Elements are visible by default,
+   so browsers without support simply skip the animation.
    ===================================================== */
 
-[data-reveal] { opacity: 0; transform: translateY(22px); transition: opacity 560ms var(--ease-pop), transform 560ms var(--ease-pop); }
-[data-reveal].is-visible { opacity: 1; transform: none; }
-@media (prefers-reduced-motion: reduce) { [data-reveal] { opacity: 1; transform: none; transition: none; } }
+@keyframes gro-reveal {
+    from { opacity: 0; transform: translateY(22px); }
+}
+
+@supports (animation-timeline: view()) {
+    @media (prefers-reduced-motion: no-preference) {
+        [data-reveal] {
+            animation: gro-reveal var(--ease-pop) both;
+            animation-timeline: view();
+            animation-range: entry 0% entry 100%;
+        }
+    }
+}
 
 @media (prefers-reduced-motion: no-preference) {
     #main.page-reveal {


### PR DESCRIPTION
## Summary
- Enable native cross-document **View Transitions** (`@view-transition { navigation: auto; }`) so navigating between index/om/workshops/bliv-med/kontakt morphs instead of hard-cutting: the sticky header stays static (no cross-fade), each inner page's opening colour block morphs into the next page's hero, and the rest of the page settles in with the brand's pop/standard easing.
- Replace the `[data-reveal]` IntersectionObserver with **native CSS scroll-driven animations** (`animation-timeline: view()`), removing ~30 lines of JS (including a special-case hack the calendar's intro scroll needed). Reveals now run off the main thread, are visible-by-default, and gracefully no-op in unsupported browsers or under `prefers-reduced-motion`.

Both are pure progressive enhancement / CSS-only — no HTML changes, and unsupported browsers (pre-Chromium 126) just get the previous behaviour (instant nav, content visible without animation).

## Test plan
- [ ] Navigate between pages in Chrome/Edge 126+ and confirm the morph transition (header stays fixed, hero block morphs colour/position/size)
- [ ] Scroll each page and confirm `[data-reveal]` sections fade/slide in as they enter the viewport
- [ ] Verify the front page's intro scroll-through-calendar still looks correct (no fade glitches)
- [ ] Confirm `prefers-reduced-motion: reduce` disables both effects
- [ ] Smoke-test in a non-Chromium browser (Firefox/Safari) — site should look/work exactly as before


---
_Generated by [Claude Code](https://claude.ai/code/session_015NZBGGkkR6YcUCwXK2PmSx)_