### PR TITLE
Slow down view transitions for a more noticeable morph

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -945,7 +945,7 @@ p { margin: 0 0 var(--space-4); max-width: 56ch; text-wrap: pretty; }
     }
 
     ::view-transition-group(root) {
-        animation-duration: 360ms;
+        animation-duration: 600ms;
         animation-timing-function: var(--ease-standard);
     }
     ::view-transition-old(root) { animation-name: gro-vt-out; }
@@ -976,7 +976,7 @@ p { margin: 0 0 var(--space-4); max-width: 56ch; text-wrap: pretty; }
         view-transition-name: page-hero;
     }
     ::view-transition-group(page-hero) {
-        animation-duration: 420ms;
+        animation-duration: 700ms;
         animation-timing-function: var(--ease-pop);
     }
 }


### PR DESCRIPTION
## Summary
- Bumps the cross-document view transition durations from PR #9 so the page-to-page morph reads more clearly: root fade/drift `360ms` → `600ms`, hero "magic move" `420ms` → `700ms`.

## Test plan
- [ ] Click between pages (e.g. Kalender → Om Gro) in a real Chrome tab (top-level navigation, not an iframe preview) and confirm the hero block now visibly morphs and the page cross-fades over ~0.6–0.7s.


---
_Generated by [Claude Code](https://claude.ai/code/session_015NZBGGkkR6YcUCwXK2PmSx)_